### PR TITLE
Remove some duplication of test data

### DIFF
--- a/test/format-mobiledoc-test.js
+++ b/test/format-mobiledoc-test.js
@@ -8,18 +8,7 @@ describe('#formatMobiledoc', function() {
   });
 
   it('falls back to JSON.stringify for unsupported version numbers', function() {
-    const oldCard = {
-      version: '0.2.0',
-      sections: [
-        [],
-        [
-          [1, 'p', [[[], 0, 'before']]],
-          [10, 'ember-card'],
-          [1, 'p', [[[], 0, 'after']]]
-        ]
-      ]
-    };
-    const expected = 
+    var expected = 
 `{
   "version": "0.2.0",
   "sections": [
@@ -54,47 +43,12 @@ describe('#formatMobiledoc', function() {
     ]
   ]
 }`;
+    var doc = JSON.parse(expected);
 
-    assert.equal(formatMobiledoc(oldCard), expected);
+    assert.equal(formatMobiledoc(doc), expected);
   });
 
   it('formats a 0.3.0 mobiledoc', function() {
-    var doc = {
-      version: "0.3.0",
-      markups: [
-        ["b"],
-        ["i"],
-        ["a", ["href", "http://google.com", "target", "_blank"]]
-      ],
-      atoms: [
-        ["mention", "@bob", {
-          id: 42
-        }],
-        ["mention", "@tom", {
-          id: 12
-        }]
-      ],
-      cards: [
-        ['image', {
-          src: 'http://google.com/logo.png'
-        }]
-      ],
-      sections: [
-        [1, "h2", [
-          [0, [], 0, "Simple h2 example"],
-        ]],
-        [1, "p", [
-          [0, [], 0, "Example with no markup"],
-          [0, [0, 1], 1, "Bold left open, italic wrapped & closed"],
-          [0, [], 1, "Some leftover bold, closes"],
-          [0, [], 1, "Example closing i tag (no opened markups, 1 closed markup)"],
-          [1, [], 0, 0],
-          [1, [0], 1, 1]
-        ]],
-        [10, 0]
-      ]
-    };
-
     var expected =
 `{
   "version": "0.3.0",
@@ -131,6 +85,8 @@ describe('#formatMobiledoc', function() {
     [10, 0]
   ]
 }`;
+
+    var doc = JSON.parse(expected);
 
     assert.equal(formatMobiledoc(doc), expected);
   });

--- a/test/formatters-test.js
+++ b/test/formatters-test.js
@@ -14,11 +14,11 @@ describe('Formatters for each mobiledoc key', function() {
     });
 
     it('formats atom payloads across multiple lines', function() {
-      var atom = ['mention', '@bob', { id: 42 }];
       var expected =
 `["mention", "@bob", {
   "id": 42
 }]`;
+      var atom = JSON.parse(expected);
       assert.equal(formatters.atom(atom), expected);
     });
   });
@@ -29,11 +29,11 @@ describe('Formatters for each mobiledoc key', function() {
     });
 
     it('formats card payload across multiple lines', function() {
-      var card = ['image', {src:'whatever'}];
       var expected =
 `["image", {
   "src": "whatever"
 }]`;
+      var card = JSON.parse(expected);
       assert.equal(formatters.card(card), expected);
     });
   });
@@ -48,18 +48,13 @@ describe('Formatters for each mobiledoc key', function() {
     });
 
     it('formats markers across multiple lines', function() {
-      var section =
-      [1, "h2", [
-        [0, [], 0, "Simple "],
-        [0, [1], 1, "h2"],
-        [0, [], 0, " example"]
-      ]];
       var expected =
 `[1, "h2", [
   [0, [], 0, "Simple "],
   [0, [1], 1, "h2"],
   [0, [], 0, " example"]
 ]]`;
+      var section = JSON.parse(expected);
       assert.equal(formatters.section(section), expected);
     });
   });

--- a/test/string-utils-test.js
+++ b/test/string-utils-test.js
@@ -19,8 +19,8 @@ describe('String utilities', function() {
 
   describe('#oneline', function() {
     it('separates array items with spaces', function() {
-      var markup = ['a', ['href', 'http://google.com', 'target', '_blank']];
       var expected = '["a", ["href", "http://google.com", "target", "_blank"]]';
+      var markup = JSON.parse(expected);
       assert.equal(utils.oneline(markup), expected);
     });
   });


### PR DESCRIPTION
Many docs had both a string and an object literal representation. Just
parsing the string with `JSON.parse` means we don't have to write the
whole thing twice.
